### PR TITLE
fix: correct app path in ZIP file

### DIFF
--- a/Casks/dropstone.rb
+++ b/Casks/dropstone.rb
@@ -7,7 +7,7 @@ cask "dropstone" do
   desc "Self-learning AI IDE that understands your codebase and automates development tasks"
   homepage "https://github.com/blankline-org/dropstone-releases"
 
-  app "Dropstone.app"
+  app "VSCode-darwin-arm64/Dropstone.app"
 
   preflight do
     system_command "/bin/rm",


### PR DESCRIPTION
Fixes #1

The ZIP file contains the app at `VSCode-darwin-arm64/Dropstone.app` but the cask was expecting it at the root level.

This PR updates the cask formula to reference the correct path, allowing the installation to complete successfully.

Tested locally and confirmed working.